### PR TITLE
fix: self-heal after Steam updates restore the vanilla portal2.exe (fixes #261, #263)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -79,6 +79,11 @@ jobs:
           # Copy all files from assets folder
           Copy-Item -Path "assets\*" -Destination $modFolder -Recurse -Force
           
+          # Ship a copy of the patched exe as the self-heal backup used by
+          # run-p2-rtx.bat / toggle-p2-rtx.bat (Steam updates restore the
+          # vanilla portal2.exe, which would otherwise disable the mod)
+          Copy-Item -Path "assets\portal2.exe" -Destination (Join-Path $modFolder "portal2-rtx\portal2.exe.p2rtx") -Force
+
           # Copy the built p2-rtx.dll to the mod folder
           $dllPath = "build\bin\Release\p2-rtx.dll"
           if (Test-Path $dllPath) {

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ for Portal 2 (`bin/.trex/NvRemixBridge.exe` & `bin/d3d9.dll`)
 
 3. Sart the game from Steam
 
+- Note: starting from Steam skips the self-repair check in `run-p2-rtx.bat`. When a Steam update for Portal 2 comes out (Steam restores the vanilla `portal2.exe`, which disables the mod), run `run-p2-rtx.bat` once to repair the install.
+
+<br></details>
+
+
+<details><summary>The mod stopped working after a Steam update</summary>
+<br>
+
+- Steam updates (and "verify integrity of game files") restore the vanilla `portal2.exe`. That removes the modification that loads `p2-rtx.dll`, so the game starts without the mod.
+
+- Run `run-p2-rtx.bat` - it detects the vanilla exe and restores the patched `portal2.exe` automatically (the vanilla exe is kept as `portal2.exe.vanilla`).
+
+- Alternatively: re-run the installer or extract the release zip over the game folder again.
+
+- Advanced: [`tools/patch_portal2_imports.py`](tools/patch_portal2_imports.py) re-applies the import patch to any vanilla `portal2.exe` (useful if the shipped exe ever goes out of date after a game update).
+
 <br></details>
 
 

--- a/assets/run-p2-rtx.bat
+++ b/assets/run-p2-rtx.bat
@@ -1,1 +1,51 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+
+set "PATCHED_BACKUP=portal2-rtx\portal2.exe.p2rtx"
+
+rem ---------------------------------------------------------------------------
+rem  Self-heal: Steam updates and "verify integrity of game files" restore the
+rem  vanilla portal2.exe, which removes the p2-rtx.dll import and silently
+rem  disables the mod. Detect that here and restore the patched exe before
+rem  launching. (the patched exe contains the string "p2-rtx.dll", vanilla
+rem  does not)
+rem ---------------------------------------------------------------------------
+
+findstr /m /c:"p2-rtx.dll" portal2.exe >nul 2>&1
+if errorlevel 1 goto :heal
+
+rem portal2.exe is patched - keep a copy so it can be restored after the next
+rem Steam update
+if not exist "portal2-rtx" mkdir "portal2-rtx"
+fc /b portal2.exe "%PATCHED_BACKUP%" >nul 2>&1
+if errorlevel 1 copy /y portal2.exe "%PATCHED_BACKUP%" >nul
+goto :launch
+
+:heal
+rem a renamed bridge dll means the user disabled the mod with toggle-p2-rtx.bat
+rem on purpose - launch the vanilla game instead of undoing that choice
+if exist "bin\d3d9.dll.off" if not exist "bin\d3d9.dll" (
+    echo [p2-rtx] The mod is disabled ^(toggle-p2-rtx.bat^) - starting the vanilla game.
+    echo [p2-rtx] Run toggle-p2-rtx.bat to re-enable the mod.
+    goto :launch
+)
+if not exist "%PATCHED_BACKUP%" (
+    echo [p2-rtx] portal2.exe does not load p2-rtx.dll and no patched backup was found.
+    echo [p2-rtx] Please re-install the mod ^(run the installer or extract the release zip again^).
+    pause
+    exit /b 1
+)
+echo [p2-rtx] A Steam update restored the vanilla portal2.exe - restoring the p2-rtx patched exe ...
+copy /y portal2.exe portal2.exe.vanilla >nul
+copy /y "%PATCHED_BACKUP%" portal2.exe >nul
+findstr /m /c:"p2-rtx.dll" portal2.exe >nul 2>&1
+if errorlevel 1 (
+    echo [p2-rtx] Failed to restore the patched portal2.exe. Please re-install the mod.
+    pause
+    exit /b 1
+)
+echo [p2-rtx] Done. ^(the vanilla exe was saved as portal2.exe.vanilla^)
+
+:launch
 START portal2.exe -insecure -steam -novid -disable_d3d9_hacks -limitvsconst -softparticlesdefaultoff -disallowhwmorph -no_compressed_verts -nogamepadui +mat_phong 1 %*

--- a/assets/toggle-p2-rtx.bat
+++ b/assets/toggle-p2-rtx.bat
@@ -1,27 +1,38 @@
 @echo off
-setlocal EnableDelayedExpansion
+setlocal
+cd /d "%~dp0"
 
-REM
-set "DLL1=bin\d3d9.dll"
-set "DLL2=bin\winmm.dll"
+set "BRIDGE=bin\d3d9.dll"
+set "PATCHED_BACKUP=portal2-rtx\portal2.exe.p2rtx"
+set "VANILLA_BACKUP=portal2.exe.vanilla"
 
-REM check current status of files
+rem ---------------------------------------------------------------------------
+rem  The mod loads because portal2.exe was patched to import p2-rtx.dll.
+rem  enabled  = patched portal2.exe + active remix bridge (bin\d3d9.dll)
+rem  disabled = vanilla portal2.exe + bridge renamed to bin\d3d9.dll.off
+rem  A vanilla exe combined with an active bridge usually means a Steam update
+rem  restored the original portal2.exe.
+rem ---------------------------------------------------------------------------
+
+set "EXE=vanilla"
+findstr /m /c:"p2-rtx.dll" portal2.exe >nul 2>&1 && set "EXE=patched"
+
 set "STATUS=unknown"
-if exist "%DLL1%" if exist "%DLL2%" set "STATUS=enabled"
-if exist "%DLL1%.off" if exist "%DLL2%.off" set "STATUS=disabled"
+if "%EXE%"=="patched" if exist "%BRIDGE%" set "STATUS=enabled"
+if "%EXE%"=="vanilla" if exist "%BRIDGE%.off" set "STATUS=disabled"
+if "%EXE%"=="vanilla" if exist "%BRIDGE%" set "STATUS=partial (vanilla exe, active bridge - Steam update?)"
+if "%EXE%"=="patched" if exist "%BRIDGE%.off" if not exist "%BRIDGE%" set "STATUS=partial (patched exe, inactive bridge)"
 
 echo Current mod status: %STATUS%
 echo.
 
-REM
 if "%STATUS%"=="unknown" (
-    echo Error: DLL files are in an inconsistent state.
-    echo Please ensure both files exist with either .dll or .dll.off extensions.
+    echo Error: neither "%BRIDGE%" nor "%BRIDGE%.off" exists.
+    echo Please re-install the mod ^(run the installer or extract the release zip again^).
     pause
-    exit /b
+    exit /b 1
 )
 
-REM
 if "%STATUS%"=="enabled" (
     set "QUESTION=Would you like to disable the mod? (y/n)"
     set "ACTION=disable"
@@ -33,21 +44,82 @@ if "%STATUS%"=="enabled" (
 :PROMPT
 set "CHOICE="
 set /p CHOICE="%QUESTION% "
+if not defined CHOICE goto :EXIT
 if /i "%CHOICE%"=="y" goto :PROCESS
 if /i "%CHOICE%"=="n" goto :EXIT
 echo Please enter y or n
 goto :PROMPT
 
 :PROCESS
-if "%ACTION%"=="disable" (
-    ren "%DLL1%" "d3d9.dll.off"
-    ren "%DLL2%" "winmm.dll.off"
-    echo Mod has been disabled
-) else (
-    ren "%DLL1%.off" "d3d9.dll"
-    ren "%DLL2%.off" "winmm.dll"
-    echo Mod has been enabled
+if "%ACTION%"=="enable" goto :ENABLE
+
+rem --- disable -----------------------------------------------------------
+rem the patched exe cannot run without p2-rtx.dll (hard import), so disabling
+rem requires restoring the vanilla exe
+if "%EXE%"=="patched" (
+    if not exist "%VANILLA_BACKUP%" (
+        echo Error: no vanilla backup "%VANILLA_BACKUP%" found.
+        echo Use Steam: right-click Portal 2 -^> Properties -^> Installed Files -^>
+        echo "Verify integrity of game files" to restore the vanilla portal2.exe,
+        echo then run this script again to deactivate the remix bridge.
+        pause
+        exit /b 1
+    )
+    rem keep a copy of the patched exe so the mod can be re-enabled
+    if not exist "portal2-rtx" mkdir "portal2-rtx"
+    copy /y portal2.exe "%PATCHED_BACKUP%" >nul
+    if errorlevel 1 goto :OPFAIL
+    copy /y "%VANILLA_BACKUP%" portal2.exe >nul
+    if errorlevel 1 goto :OPFAIL
 )
+if exist "%BRIDGE%" (
+    rem the active bridge dll is authoritative - drop a leftover .off copy
+    if exist "%BRIDGE%.off" del "%BRIDGE%.off" >nul 2>&1
+    ren "%BRIDGE%" "d3d9.dll.off"
+    if errorlevel 1 goto :OPFAIL
+)
+rem verify the resulting state before claiming success
+findstr /m /c:"p2-rtx.dll" portal2.exe >nul 2>&1
+if not errorlevel 1 goto :OPFAIL
+if exist "%BRIDGE%" goto :OPFAIL
+echo Mod has been disabled.
+echo See the README's "How do I disable remix?" section for game cvars you
+echo might want to reset ^(r_portal_stencil_depth 2, mat_fullbright 0, ...^).
+goto :EXIT
+
+:ENABLE
+if "%EXE%"=="vanilla" (
+    if not exist "%PATCHED_BACKUP%" (
+        echo Error: no patched backup "%PATCHED_BACKUP%" found.
+        echo Please re-install the mod ^(run the installer or extract the release zip again^).
+        pause
+        exit /b 1
+    )
+    copy /y portal2.exe "%VANILLA_BACKUP%" >nul
+    if errorlevel 1 goto :OPFAIL
+    copy /y "%PATCHED_BACKUP%" portal2.exe >nul
+    if errorlevel 1 goto :OPFAIL
+)
+if exist "%BRIDGE%.off" if not exist "%BRIDGE%" (
+    ren "%BRIDGE%.off" "d3d9.dll"
+    if errorlevel 1 goto :OPFAIL
+)
+rem verify the resulting state before claiming success
+findstr /m /c:"p2-rtx.dll" portal2.exe >nul 2>&1
+if errorlevel 1 goto :OPFAIL
+if not exist "%BRIDGE%" goto :OPFAIL
+rem clean up a leftover .off copy so the status check stays unambiguous
+if exist "%BRIDGE%.off" del "%BRIDGE%.off" >nul 2>&1
+echo Mod has been enabled.
+goto :EXIT
+
+:OPFAIL
+echo.
+echo Error: a file operation failed or the result could not be verified.
+echo ^(is the game still running? are portal2.exe or bin\d3d9.dll read-only?^)
+echo Please close the game, check the files and run this script again.
+pause
+exit /b 1
 
 :EXIT
 echo.

--- a/src/std_include.hpp
+++ b/src/std_include.hpp
@@ -6,7 +6,7 @@
 
 constexpr auto COMP_MOD_VERSION_MAJOR = 2;
 constexpr auto COMP_MOD_VERSION_MINOR = 3;
-constexpr auto COMP_MOD_VERSION_PATCH = 0;
+constexpr auto COMP_MOD_VERSION_PATCH = 1;
 
 #define COMPMOD_ASSET_DIR "\\portal2-rtx\\"
 

--- a/src_installer/installer.cpp
+++ b/src_installer/installer.cpp
@@ -42,6 +42,30 @@ bool file_exists(const std::string& path)
     return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
 }
 
+// the p2-rtx patched portal2.exe contains the imported dll name as a plain string
+// returns 1 = has the import, 0 = vanilla, -1 = could not read the file
+int exe_p2rtx_import_state(const std::string& exe_path)
+{
+	std::error_code ec;
+	const auto size = std::filesystem::file_size(exe_path, ec);
+	if (ec || !size) {
+		return -1;
+	}
+
+	std::ifstream file(exe_path, std::ios::binary);
+	if (!file.is_open()) {
+		return -1;
+	}
+
+	std::string data(static_cast<size_t>(size), '\0');
+	file.read(data.data(), static_cast<std::streamsize>(size));
+	if (file.gcount() != static_cast<std::streamsize>(size)) {
+		return -1;
+	}
+
+	return data.find("p2-rtx.dll") != std::string::npos ? 1 : 0;
+}
+
 std::filesystem::path get_installer_dir()
 {
 	wchar_t buf[MAX_PATH] = { 0 };
@@ -545,6 +569,18 @@ int main()
 		Sleep(25);
 	}
 
+	// keep a copy of the untouched exe so the mod can be cleanly disabled later
+	// (the extracted files replace portal2.exe with the p2-rtx import-patched one)
+	// an unreadable exe must not count as vanilla - that would clobber the backup
+	if (file_exists(portal2_exe_path) && exe_p2rtx_import_state(portal2_exe_path) == 0)
+	{
+		if (CopyFileA(portal2_exe_path.c_str(), (game_dir + "\\portal2.exe.vanilla").c_str(), FALSE))
+		{
+			std::cout << "Backed up the vanilla portal2.exe to 'portal2.exe.vanilla'\n";
+		}
+		Sleep(25);
+	}
+
 	// check if comp mod and remix are installed -> update
 	const bool has_remix_comp_mod = file_exists(game_dir + "\\bin\\d3d9.dll") &&
 									file_exists(game_dir + "\\p2-rtx.dll");
@@ -672,6 +708,6 @@ int main()
 
 	std::cout << "\n\nIf you run into issues, please create an issue on the GitHub repository.\n> Please include 'portal2-rtx/logs/logfile.txt'\n> The log files from 'rtx-remix/logs'\n> A short description and anything else that might help to identify the issue.\n";
 
-	MessageBoxA(nullptr, "Installation complete!\nYou can now launch Portal 2\nby running run-p2-rtx.bat", "Success", MB_ICONINFORMATION);
+	MessageBoxA(nullptr, "Installation complete!\nYou can now launch Portal 2\nby running run-p2-rtx.bat\n\nNote: Steam updates restore the vanilla portal2.exe and disable the mod.\nrun-p2-rtx.bat detects this and repairs the install automatically.", "Success", MB_ICONINFORMATION);
     return 0;
 }

--- a/tools/patch_portal2_imports.py
+++ b/tools/patch_portal2_imports.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Re-create the p2-rtx import-patched portal2.exe from a vanilla one.
+
+p2-rtx loads by adding ``p2-rtx.dll`` to portal2.exe's import table, so the
+game itself pulls the mod in at process start (no ASI loader, no dll proxy).
+Steam's update/verify flow restores the vanilla portal2.exe, which silently
+disables the mod. This tool re-applies the import patch to any vanilla
+portal2.exe so an update never requires shipping a new binary:
+
+  * a new import table is appended in a 512-byte block past the last section
+    (the existing descriptors are copied verbatim, then a descriptor for
+    p2-rtx.dll importing AmdPowerXpressRequestHighPerformance and
+    NvOptimusEnablement is added),
+  * the last section is extended to cover the block (write enabled,
+    discardable cleared),
+  * every section holding an existing IAT is made writable,
+  * SizeOfImage and the import data directory are updated.
+
+Given the vanilla exe of game build 23973718 the output is byte-identical to
+the previously shipped pre-patched exe (SHA1 cca4a727...).
+
+Usage:
+  python patch_portal2_imports.py <portal2.exe> [-o output.exe]
+
+Without -o the file is patched in place and the vanilla original is kept
+next to it as portal2.exe.vanilla. Already-patched files are detected and
+left untouched. Stdlib only; Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import struct
+import sys
+from pathlib import Path
+
+DLL_NAME = b"p2-rtx.dll"
+IMPORT_FUNCS = [b"AmdPowerXpressRequestHighPerformance", b"NvOptimusEnablement"]
+
+# Known hashes for game build 23973718 (informational - the patch itself is
+# generic and works on any 32-bit portal2.exe).
+SHA1_VANILLA_23973718 = "754149fc8da2e131c2f13324c9e087f2a690f197"
+SHA1_PATCHED_23973718 = "cca4a727f24b3e2eca89cbcc9e2f74908d0ce578"
+
+IMAGE_SCN_MEM_DISCARDABLE = 0x02000000
+IMAGE_SCN_MEM_WRITE = 0x80000000
+
+
+class PatchError(Exception):
+    pass
+
+
+def align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) & ~(alignment - 1)
+
+
+def sha1(data: bytes) -> str:
+    return hashlib.sha1(data).hexdigest()
+
+
+class Pe32:
+    """Minimal 32-bit PE reader/patcher over a mutable byte buffer."""
+
+    def __init__(self, data: bytearray):
+        self.data = data
+        if data[:2] != b"MZ":
+            raise PatchError("not an MZ executable")
+        (self.e_lfanew,) = struct.unpack_from("<I", data, 0x3C)
+        if data[self.e_lfanew : self.e_lfanew + 4] != b"PE\0\0":
+            raise PatchError("PE signature not found")
+        self.file_header = self.e_lfanew + 4
+        (self.num_sections,) = struct.unpack_from("<H", data, self.file_header + 2)
+        (opt_size,) = struct.unpack_from("<H", data, self.file_header + 16)
+        self.opt_header = self.file_header + 20
+        (magic,) = struct.unpack_from("<H", data, self.opt_header)
+        if magic != 0x10B:
+            raise PatchError(f"not a PE32 (32-bit) image, optional header magic {magic:#x}")
+        (self.section_align,) = struct.unpack_from("<I", data, self.opt_header + 32)
+        (self.file_align,) = struct.unpack_from("<I", data, self.opt_header + 36)
+        self.section_table = self.opt_header + opt_size
+
+    # -- optional header fields ------------------------------------------------
+    @property
+    def size_of_image(self) -> int:
+        return struct.unpack_from("<I", self.data, self.opt_header + 56)[0]
+
+    @size_of_image.setter
+    def size_of_image(self, value: int) -> None:
+        struct.pack_into("<I", self.data, self.opt_header + 56, value)
+
+    @property
+    def checksum(self) -> int:
+        return struct.unpack_from("<I", self.data, self.opt_header + 64)[0]
+
+    @checksum.setter
+    def checksum(self, value: int) -> None:
+        struct.pack_into("<I", self.data, self.opt_header + 64, value)
+
+    def data_directory(self, index: int) -> tuple[int, int]:
+        off = self.opt_header + 96 + index * 8
+        return struct.unpack_from("<II", self.data, off)
+
+    def set_data_directory(self, index: int, rva: int, size: int) -> None:
+        struct.pack_into("<II", self.data, self.opt_header + 96 + index * 8, rva, size)
+
+    # -- sections --------------------------------------------------------------
+    def section(self, index: int) -> dict:
+        off = self.section_table + index * 40
+        name, vsize, va, raw_size, raw_ptr = struct.unpack_from("<8sIIII", self.data, off)
+        (chars,) = struct.unpack_from("<I", self.data, off + 36)
+        return {
+            "index": index,
+            "offset": off,
+            "name": name.rstrip(b"\0").decode(errors="replace"),
+            "vsize": vsize,
+            "va": va,
+            "raw_size": raw_size,
+            "raw_ptr": raw_ptr,
+            "chars": chars,
+        }
+
+    def sections(self) -> list[dict]:
+        return [self.section(i) for i in range(self.num_sections)]
+
+    def section_containing_rva(self, rva: int) -> dict:
+        for s in self.sections():
+            span = max(s["vsize"], s["raw_size"])
+            if s["va"] <= rva < s["va"] + align_up(span, self.section_align):
+                return s
+        raise PatchError(f"no section contains RVA {rva:#x}")
+
+    def rva_to_offset(self, rva: int) -> int:
+        s = self.section_containing_rva(rva)
+        delta = rva - s["va"]
+        if delta >= s["raw_size"]:
+            raise PatchError(f"RVA {rva:#x} has no file-backed data")
+        return s["raw_ptr"] + delta
+
+
+def read_import_descriptors(pe: Pe32) -> tuple[list[bytes], set[int]]:
+    """Return raw 20-byte import descriptors and the set of IAT (FirstThunk) RVAs."""
+    imp_rva, _ = pe.data_directory(1)
+    if imp_rva == 0:
+        raise PatchError("image has no import table")
+    descriptors: list[bytes] = []
+    iat_rvas: set[int] = set()
+    off = pe.rva_to_offset(imp_rva)
+    while True:
+        raw = bytes(pe.data[off : off + 20])
+        if raw == b"\0" * 20:
+            break
+        descriptors.append(raw)
+        iat_rvas.add(struct.unpack_from("<I", raw, 16)[0])
+        off += 20
+    return descriptors, iat_rvas
+
+
+def build_import_block(pe: Pe32, block_rva: int) -> bytes:
+    """Build the appended block: descriptors + name + hint/names + IAT + INT."""
+    old_descriptors, _ = read_import_descriptors(pe)
+
+    n_desc = len(old_descriptors) + 2  # +new dll, +null terminator
+    name_off = n_desc * 20
+    hint_offs = []
+    cursor = name_off + len(DLL_NAME) + 1
+    for func in IMPORT_FUNCS:
+        hint_offs.append(cursor)
+        cursor += 2 + len(func) + 1  # hint word + name + NUL
+    iat_off = cursor
+    cursor += (len(IMPORT_FUNCS) + 1) * 4
+    int_off = cursor
+    cursor += (len(IMPORT_FUNCS) + 1) * 4
+
+    block = bytearray(align_up(cursor, pe.file_align))
+
+    pos = 0
+    for raw in old_descriptors:
+        block[pos : pos + 20] = raw
+        pos += 20
+    struct.pack_into(
+        "<5I", block, pos,
+        block_rva + int_off, 0, 0, block_rva + name_off, block_rva + iat_off,
+    )
+    # null terminator descriptor is already zero
+
+    block[name_off : name_off + len(DLL_NAME)] = DLL_NAME
+    for func, off in zip(IMPORT_FUNCS, hint_offs):
+        block[off + 2 : off + 2 + len(func)] = func  # hint stays 0
+    thunks = [block_rva + off for off in hint_offs] + [0]
+    struct.pack_into(f"<{len(thunks)}I", block, iat_off, *thunks)
+    struct.pack_into(f"<{len(thunks)}I", block, int_off, *thunks)
+
+    return bytes(block), cursor, len(old_descriptors) + 1
+
+
+def is_already_patched(pe: Pe32) -> bool:
+    try:
+        descriptors, _ = read_import_descriptors(pe)
+    except PatchError:
+        return False
+    for raw in descriptors:
+        name_rva = struct.unpack_from("<I", raw, 12)[0]
+        try:
+            off = pe.rva_to_offset(name_rva)
+        except PatchError:
+            continue
+        name = bytes(pe.data[off : off + len(DLL_NAME) + 1])
+        if name.lower() == DLL_NAME.lower() + b"\0":
+            return True
+    return False
+
+
+def patch(data: bytes) -> bytes:
+    pe = Pe32(bytearray(data))
+
+    bound_rva, bound_size = pe.data_directory(11)
+    if bound_rva or bound_size:
+        raise PatchError("image uses bound imports; refusing to patch")
+
+    last = max(pe.sections(), key=lambda s: s["va"])
+    if last["raw_ptr"] + last["raw_size"] != len(pe.data):
+        raise PatchError(
+            "last section does not end at EOF "
+            f"({last['raw_ptr'] + last['raw_size']:#x} vs {len(pe.data):#x}); "
+            "overlay data present - refusing to patch"
+        )
+    if pe.size_of_image != align_up(last["va"] + last["vsize"], pe.section_align):
+        raise PatchError("SizeOfImage does not follow the last section; unexpected layout")
+
+    # Bytes appended to the last section's raw data are mapped directly after
+    # its existing raw data - NOT at SizeOfImage, which only coincides when
+    # the raw size equals the section-aligned virtual size.
+    if last["vsize"] > last["raw_size"]:
+        raise PatchError(
+            "last section has virtual-only (zero-fill) data past its raw data; "
+            "appended bytes would overlap it - refusing to patch"
+        )
+    block_rva = last["va"] + last["raw_size"]
+
+    block, used, _ = build_import_block(pe, block_rva)
+    _, iat_rvas = read_import_descriptors(pe)
+
+    # Extend the last section over the appended block.
+    off = last["offset"]
+    struct.pack_into("<I", pe.data, off + 8, block_rva + used - last["va"])  # VirtualSize
+    struct.pack_into("<I", pe.data, off + 16, last["raw_size"] + len(block))  # SizeOfRawData
+    chars = (last["chars"] | IMAGE_SCN_MEM_WRITE) & ~IMAGE_SCN_MEM_DISCARDABLE
+    struct.pack_into("<I", pe.data, off + 36, chars)
+
+    # The loader writes resolved addresses into the original IATs - make their
+    # sections writable (the shipped patched exe does the same for .rdata).
+    for rva in iat_rvas:
+        s = pe.section_containing_rva(rva)
+        struct.pack_into("<I", pe.data, s["offset"] + 36, s["chars"] | IMAGE_SCN_MEM_WRITE)
+
+    pe.size_of_image = max(pe.size_of_image, align_up(block_rva + used, pe.section_align))
+    pe.set_data_directory(1, block_rva, (len(read_import_descriptors(pe)[0]) + 2) * 20)
+    if pe.checksum:
+        pe.checksum = 0  # stale after edits; loader does not verify exe checksums
+
+    return bytes(pe.data) + block
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("exe", type=Path, help="path to portal2.exe")
+    ap.add_argument("-o", "--output", type=Path,
+                    help="write patched exe here instead of patching in place")
+    ap.add_argument("--check", action="store_true",
+                    help="only report whether the exe is patched (exit 0), vanilla (exit 1) "
+                         "or not a patchable PE (exit 2)")
+    args = ap.parse_args(argv)
+
+    data = args.exe.read_bytes()
+    try:
+        pe = Pe32(bytearray(data))
+        already = is_already_patched(pe)
+    except (PatchError, struct.error) as e:
+        print(f"{args.exe}: not a patchable 32-bit PE: {e}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        if already:
+            print(f"{args.exe}: patched (imports {DLL_NAME.decode()})")
+            return 0
+        print(f"{args.exe}: vanilla (no {DLL_NAME.decode()} import)")
+        return 1
+
+    if already:
+        print(f"{args.exe}: already imports {DLL_NAME.decode()} - nothing to do")
+        if args.output:
+            args.output.write_bytes(data)
+            print(f"copied unchanged to {args.output}")
+        return 0
+
+    in_sha = sha1(data)
+    if in_sha != SHA1_VANILLA_23973718:
+        print(f"note: input SHA1 {in_sha} is not the known build-23973718 vanilla exe; "
+              "patching generically")
+
+    try:
+        patched = patch(data)
+    except PatchError as e:
+        print(f"{args.exe}: cannot patch: {e}", file=sys.stderr)
+        return 3
+
+    if args.output:
+        args.output.write_bytes(patched)
+        target = args.output
+    else:
+        # the input was just proven vanilla - always refresh the backup so a
+        # Steam update's newer vanilla exe is never lost to a stale copy
+        backup = args.exe.with_suffix(args.exe.suffix + ".vanilla")
+        shutil.copy2(args.exe, backup)
+        print(f"vanilla exe backed up to {backup}")
+        args.exe.write_bytes(patched)
+        target = args.exe
+
+    out_sha = sha1(patched)
+    print(f"patched {target} ({len(data)} -> {len(patched)} bytes, SHA1 {out_sha})")
+    if in_sha == SHA1_VANILLA_23973718:
+        if out_sha == SHA1_PATCHED_23973718:
+            print("verified: byte-identical to the known-good patched exe")
+        else:
+            print("ERROR: output does not match the known-good patched exe", file=sys.stderr)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Since the June 2026 update (build 23973718) the mod silently stops working (#261, #263). The game itself didn't break anything - all hooked binaries and VPK indexes are byte-identical to the pre-update build. Steam's restage just restores the **vanilla `portal2.exe`** over the shipped import-patched one, so `p2-rtx.dll` never loads. "Verify integrity of game files" does the same, and the only fix today is a full re-install.

## Changes

- **`run-p2-rtx.bat` self-heals**: if `portal2.exe` no longer imports `p2-rtx.dll`, it restores the patched exe from `portal2-rtx/portal2.exe.p2rtx` (now shipped in the release zip) and keeps the vanilla exe as `portal2.exe.vanilla`. A deliberate toggle-disable is respected.
- **`toggle-p2-rtx.bat` rewritten**: the old script still required `bin/winmm.dll` (removed in b21e5e) and errored on every current install; it also never touched the patched exe, which hard-imports `p2-rtx.dll`. The new one swaps patched/vanilla exe + bridge dll together and verifies every file operation before reporting success.
- **Installer** backs up the vanilla `portal2.exe` before extraction.
- **`tools/patch_portal2_imports.py`**: stdlib-only Python that regenerates the patched exe from any vanilla `portal2.exe` - byte-identical to `assets/portal2.exe` for the current build, in case Valve ever ships a different exe.
- README troubleshooting entry + version bump to 2.3.1.

## Testing

40-check sandbox suite for the batch logic (all state transitions, Steam-update partial states, read-only/failed operations), byte-identity + exit-code tests for the patcher, clean Release/Win32 build, and a repaired install verified against build 23973718 locally.
